### PR TITLE
Fix code scanning alert no. 3: Disabled Spring CSRF protection

### DIFF
--- a/Discovery-Server/src/main/java/com/arivanamin/healthcare/backend/discovery/infrastructure/config/EurekaSecurityConfig.java
+++ b/Discovery-Server/src/main/java/com/arivanamin/healthcare/backend/discovery/infrastructure/config/EurekaSecurityConfig.java
@@ -24,8 +24,7 @@ public class EurekaSecurityConfig {
     
     @Bean
     public SecurityFilterChain filterChain (HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
-            .authorizeHttpRequests((registry) -> registry.anyRequest().authenticated())
+        http.authorizeHttpRequests((registry) -> registry.anyRequest().authenticated())
             .httpBasic(withDefaults());
         return http.build();
     }


### PR DESCRIPTION
Fixes [https://github.com/arivan-amin/Healthcare-Clean-Microservices/security/code-scanning/3](https://github.com/arivan-amin/Healthcare-Clean-Microservices/security/code-scanning/3)

To fix the problem, we need to enable CSRF protection in the `EurekaSecurityConfig` class. This involves removing the line that disables CSRF protection and allowing Spring Security to handle CSRF tokens by default.

- **General Fix:** Remove the line that disables CSRF protection.
- **Detailed Fix:** Modify the `filterChain` method in the `EurekaSecurityConfig` class to remove the call to `http.csrf(AbstractHttpConfigurer::disable)`.
- **Specific Changes:** Edit the `filterChain` method in the `EurekaSecurityConfig` class located in `Discovery-Server/src/main/java/com/arivanamin/healthcare/backend/discovery/infrastructure/config/EurekaSecurityConfig.java`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
